### PR TITLE
Add responsive NavigationRail labels for large screens

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:english_words/english_words.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:provider/provider.dart';
 
 void main() => runApp(const MyApp());
@@ -74,37 +75,40 @@ class _MyHomePageState extends State<MyHomePage> {
         throw UnimplementedError('no widget for $selectedIndex');
     }
 
-    return Scaffold(
-      body: Row(
-        children: [
-          SafeArea(
-            child: NavigationRail(
-              extended: false, // display label or not
-              destinations: [
-                NavigationRailDestination(
-                  icon: Icon(Icons.home),
-                  label: Text('Home'),
-                ),
-                NavigationRailDestination(
-                  icon: Icon(Icons.favorite),
-                  label: Text('Favorites'),
-                ),
-              ],
-              selectedIndex: selectedIndex,
-              onDestinationSelected: (value) => setState(() {
-                selectedIndex = value;
-              }),
+    return LayoutBuilder(builder: (context, Constraints) {
+      return Scaffold(
+        body: Row(
+          children: [
+            SafeArea(
+              child: NavigationRail(
+                // display label or not
+                extended: Constraints.maxWidth >= 600,
+                destinations: [
+                  NavigationRailDestination(
+                    icon: Icon(Icons.home),
+                    label: Text('Home'),
+                  ),
+                  NavigationRailDestination(
+                    icon: Icon(Icons.favorite),
+                    label: Text('Favorites'),
+                  ),
+                ],
+                selectedIndex: selectedIndex,
+                onDestinationSelected: (value) => setState(() {
+                  selectedIndex = value;
+                }),
+              ),
             ),
-          ),
-          Expanded(
-            child: Container(
-              color: Theme.of(context).colorScheme.primaryContainer,
-              child: page,
+            Expanded(
+              child: Container(
+                color: Theme.of(context).colorScheme.primaryContainer,
+                child: page,
+              ),
             ),
-          ),
-        ],
-      ),
-    );
+          ],
+        ),
+      );
+    });
   }
 }
 


### PR DESCRIPTION
## What
Implemented a responsive design in **`_MyHomePageState`** using **`LayoutBuilder`** to show NavigationRail labels on large screens.

## Why
To improve user experience by displaying labels next to icons on larger screens (width >= 600).

## How
- Wrapped **`Scaffold`** with **`LayoutBuilder`** in **`_MyHomePageState`**.
- Display NavigationRail labels when screen width is 600 or more.

## Visuals

![flutter_namer_responsive](https://github.com/call-me-bammer/flutter_namer_tutorial/assets/38589666/bbd99eab-d426-4147-a948-e1b061947b86)

Please review the changes and let me know if there are any improvements needed.